### PR TITLE
Update .gitmodules for dvgo_cuda

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "externals/waymo-open-dataset"]
 	path = externals/waymo-open-dataset
 	url = https://github.com/waymo-research/waymo-open-dataset.git
+[submodule "externals/dvgo_cuda"]
+        path = externals/dvgo_cuda
+        url = https://github.com/sunset1995/DirectVoxGO.git

--- a/src/dwm/models/base_vq_models/dvgo_utils.py
+++ b/src/dwm/models/base_vq_models/dvgo_utils.py
@@ -5,13 +5,12 @@ import torch.nn.functional as F
 from torch.utils.cpp_extension import load
 
 parent_dir = os.path.dirname(os.path.abspath(__file__))
+cpp_file = os.path.join(parent_dir, '../../../../externals/dvgo_cuda/lib/cuda/render_utils.cpp')
+cu_file = os.path.join(parent_dir, '../../../../externals/dvgo_cuda/lib/cuda/render_utils_kernel.cu')
 render_utils_cuda = load(
     name='render_utils_cuda',
-    sources=[
-        os.path.join(parent_dir, path)
-        for path in ['../../../../externals/dvgo_cuda/render_utils.cpp', '../../../../externals/dvgo_cuda/render_utils_kernel.cu']],
+    sources=[cpp_file, cu_file],
     verbose=True)
-
 
 def sample_ray(rays_o, rays_d, near, far, stepsize, xyz_min, xyz_max, voxel_size):
     '''Sample query points on rays.


### PR DESCRIPTION
Add dvgo_cuda submodule for lidar inference example.

There is a error during running lidar generation example, seems need to add this module.

![image](https://github.com/user-attachments/assets/48f0dcaf-6822-4cce-8919-5ca8844d655f)
